### PR TITLE
Fixed log output on variadic arguments

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -117,8 +117,9 @@ function factory(Object, log, jjv, jjve, schema)
 
       var fn_method_raw = fn_original_factory(method_name, log_level, logger_name);
 
-      return function(message) {
+      return function() {
 
+        var args, i;
         var date = new Date();
         var prefix = parameters.prefixes.reduce(function(result, prefix_name) {
 
@@ -154,8 +155,12 @@ function factory(Object, log, jjv, jjve, schema)
           }, prefix);
         }
 
-        message = typeof message === 'object' ? JSON.stringify(message) :  message;
-        fn_method_raw(parameters.prefixFormat.replace(/%p/, prefix) + message);
+        prefix = parameters.prefixFormat.replace(/%p/, prefix);
+        args = [prefix];
+        for (i = 0; i < arguments.length; i++) {
+            args.push(arguments[i]);
+        }
+        fn_method_raw.apply(this, args);
 
       };
 

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -104,9 +104,17 @@ function factory(chai, log, Object, mock_date, loglevelMessagePrefix)
       loglevelMessagePrefix(logger, {
         prefixes: ['level']
       }, function() {
-        return function(msg)
+        return function()
         {
-          message = msg;
+          var args = [];
+          for (var i = 0; i < arguments.length; ++i) {
+              if (typeof arguments[i] === 'object') {
+                  args.push(JSON.stringify(arguments[i]));
+              } else {
+                  args.push(arguments[i].toString());
+              }
+          }
+          message = args.join('');
         };
       });
 
@@ -125,9 +133,17 @@ function factory(chai, log, Object, mock_date, loglevelMessagePrefix)
         prefixes: [],
         staticPrefixes: ['foo', 'bar']
       }, function() {
-        return function(msg)
+        return function()
         {
-          message = msg;
+          var args = [];
+          for (var i = 0; i < arguments.length; ++i) {
+              if (typeof arguments[i] === 'object') {
+                  args.push(JSON.stringify(arguments[i]));
+              } else {
+                  args.push(arguments[i].toString());
+              }
+          }
+          message = args.join('');
         };
       });
 
@@ -159,9 +175,17 @@ function factory(chai, log, Object, mock_date, loglevelMessagePrefix)
           }
         }
       }, function() {
-        return function(msg)
+        return function()
         {
-          message = msg;
+          var args = [];
+          for (var i = 0; i < arguments.length; ++i) {
+              if (typeof arguments[i] === 'object') {
+                  args.push(JSON.stringify(arguments[i]));
+              } else {
+                  args.push(arguments[i].toString());
+              }
+          }
+          message = args.join('');
         };
       });
 
@@ -170,6 +194,35 @@ function factory(chai, log, Object, mock_date, loglevelMessagePrefix)
       mock_date.reset();
 
       expect(message).to.equal('[' + timestamp + '/foobar]: TEST');
+
+    });
+
+    it("Should accepts variadic arguments", function() {
+
+      var messages,
+      logger = log.getLogger('foo');
+
+      loglevelMessagePrefix(logger, {
+        prefixes: ['level']
+      }, function() {
+        return function()
+        {
+          messages = arguments;
+        };
+      });
+
+      logger.warn(1, 'TEST', true);
+
+      expect(messages.length).to.equal(4);
+      expect(messages[0]).to.equal('[WARN]: ');
+      expect(messages[1]).to.equal(1);
+      expect(messages[2]).to.equal('TEST');
+      expect(messages[3]).to.equal(true);
+
+      logger.warn();
+
+      expect(messages.length).to.equal(1);
+      expect(messages[0]).to.equal('[WARN]: ');
 
     });
 


### PR DESCRIPTION
### Code

``` js
var log = require('loglevel-message-prefix')(require('loglevel'));
log.warn(1, 2, 3);
```
### Description

Previously, `log.*` methods only output first argument after applied
this plugin.

```
[2016-04-19 23:29:02 WARN]:  1
```

So I fixed it could receive variadic arguments.  It now outputs all
arguments as below like `console.log`.

```
[2016-04-19 23:29:02 WARN]:  1 2 3
```
